### PR TITLE
Bluetooth Keyboard "Enter" Support and WeakReference nulls

### DIFF
--- a/applock/src/main/java/com/guardanis/applock/dialogs/UnlockDialogBuilder.java
+++ b/applock/src/main/java/com/guardanis/applock/dialogs/UnlockDialogBuilder.java
@@ -12,8 +12,8 @@ import java.lang.ref.WeakReference;
 
 public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewController> implements UnlockViewController.Delegate {
 
-    protected WeakReference<Runnable> unlockCallback = new WeakReference<Runnable>(null);
-    protected WeakReference<Runnable> canceledCallback = new WeakReference<Runnable>(null);
+    protected Runnable unlockCallback = null;
+    protected Runnable canceledCallback = nulll;
 
     public UnlockDialogBuilder(Activity activity) {
         super(activity, R.layout.applock__unlock);
@@ -23,7 +23,7 @@ public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewControll
      * Set a Runnable to be triggered when a user has successfully unlocked.
      */
     public UnlockDialogBuilder onUnlocked(Runnable unlockCallback) {
-        this.unlockCallback = new WeakReference<Runnable>(unlockCallback);
+        this.unlockCallback = unlockCallback
 
         return this;
     }
@@ -32,7 +32,7 @@ public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewControll
      * Set a Runnable to be triggered when a user has canceled unlocking.
      */
     public UnlockDialogBuilder onCanceled(Runnable canceledCallback) {
-        this.canceledCallback = new WeakReference<Runnable>(canceledCallback);
+        this.canceledCallback = canceledCallback;
 
         return this;
     }
@@ -49,20 +49,20 @@ public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewControll
     public void onUnlockSuccessful() {
         dismissDialog();
 
-        final Runnable unlockCallback = this.unlockCallback.get();
-
         if(unlockCallback != null)
             unlockCallback.run();
+
+        unlockCallback = null;
     }
 
     @Override
     protected void handleCanceled() {
         super.handleCanceled();
 
-        final Runnable canceledCallback = this.canceledCallback.get();
-
         if(canceledCallback != null)
             canceledCallback.run();
+
+        canceledCallback = null;
     }
 
     /**
@@ -78,10 +78,10 @@ public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewControll
             return null;
 
         if (!AppLock.isEnrolled(activity)) {
-            final Runnable unlockCallback = this.unlockCallback.get();
-
             if(unlockCallback != null)
                 unlockCallback.run();
+
+            unlockCallback = null;
 
             return null;
         }
@@ -103,10 +103,10 @@ public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewControll
             return null;
 
         if (!AppLock.isUnlockRequired(activity, longValidDurationMs)) {
-            final Runnable unlockCallback = this.unlockCallback.get();
-
             if(unlockCallback != null)
                 unlockCallback.run();
+
+            unlockCallback = null;
 
             return null;
         }

--- a/applock/src/main/java/com/guardanis/applock/dialogs/UnlockDialogBuilder.java
+++ b/applock/src/main/java/com/guardanis/applock/dialogs/UnlockDialogBuilder.java
@@ -8,12 +8,10 @@ import com.guardanis.applock.AppLock;
 import com.guardanis.applock.R;
 import com.guardanis.applock.views.UnlockViewController;
 
-import java.lang.ref.WeakReference;
-
 public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewController> implements UnlockViewController.Delegate {
 
-    protected Runnable unlockCallback = null;
-    protected Runnable canceledCallback = nulll;
+    private Runnable unlockCallback = null;
+    private Runnable canceledCallback = null;
 
     public UnlockDialogBuilder(Activity activity) {
         super(activity, R.layout.applock__unlock);
@@ -23,7 +21,7 @@ public class UnlockDialogBuilder extends AppLockDialogBuilder<UnlockViewControll
      * Set a Runnable to be triggered when a user has successfully unlocked.
      */
     public UnlockDialogBuilder onUnlocked(Runnable unlockCallback) {
-        this.unlockCallback = unlockCallback
+        this.unlockCallback = unlockCallback;
 
         return this;
     }

--- a/applock/src/main/java/com/guardanis/applock/pin/PINInputController.java
+++ b/applock/src/main/java/com/guardanis/applock/pin/PINInputController.java
@@ -76,6 +76,10 @@ public class PINInputController implements TextView.OnEditorActionListener {
     }
 
     private boolean isSoftKeyboardFinishedAction(TextView view, int action, KeyEvent event) {
+        // Enter clicked on Bluetooth Keyboard (action is zero on hardware keyboards)
+        if (action == 0 && event.getAction() == KeyEvent.ACTION_DOWN && event.getKeyCode() == KeyEvent.KEYCODE_ENTER)
+            return true;
+
         // Some devices return null event on editor actions for Enter Button
         return (event == null || event.getAction() == KeyEvent.ACTION_DOWN)
                 && (action == EditorInfo.IME_ACTION_DONE


### PR DESCRIPTION
When using a Bluetooth keyboard the "enter" key wouldn't work to submit the pin dialog because hardware keyboards always have an IME action int of 0. Additionally, I noticed maybe 1 in 4 times my unlocked and canceled callbacks weren't being hit because when getting the runnable from the WeakReference it was null.