### PR TITLE
Android 9 keyboard not showing fix

### DIFF
--- a/applock/src/main/java/com/guardanis/applock/pin/PINInputView.java
+++ b/applock/src/main/java/com/guardanis/applock/pin/PINInputView.java
@@ -75,10 +75,9 @@ public class PINInputView extends LinearLayout implements TextWatcher {
         editText.setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI|EditorInfo.IME_ACTION_DONE);
         editText.addTextChangedListener(this);
 
-
-        //editText.setHeight(1);
-        //editText.setWidth(1);
-
+        // Can cause problems with keyboard not showing an 9 and above if not set
+        editText.setHeight(1);
+        editText.setWidth(1);
 
         addView(editText);
     }

--- a/applock/src/main/java/com/guardanis/applock/pin/PINInputView.java
+++ b/applock/src/main/java/com/guardanis/applock/pin/PINInputView.java
@@ -72,8 +72,13 @@ public class PINInputView extends LinearLayout implements TextWatcher {
         editText.setTextColor(getResources().getColor(android.R.color.transparent));
         editText.setCursorVisible(false);
         editText.setInputType(InputType.TYPE_CLASS_NUMBER);
-        editText.setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI);
+        editText.setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI|EditorInfo.IME_ACTION_DONE);
         editText.addTextChangedListener(this);
+
+
+        //editText.setHeight(1);
+        //editText.setWidth(1);
+
 
         addView(editText);
     }


### PR DESCRIPTION
Been using this library in a project for work and we ran into a problem where the keyboard would not appear on Android 9. After many attempts at other fixes the root problem ended up being solved by setting a 1px height/width on the PINInputView edit text as well as adding the IME_DONE_ACTION flag in addition to the NO_UI IME flag. The sample doesn't seem to have this problem (oddly) but if you create a new project and add the library the problem can be replicated on Android 9.